### PR TITLE
Attempt to fix an error that seems to cause rendering glitches elsewhere

### DIFF
--- a/src/main/java/cyano/electricadvantage/machines/ElectricFurnaceTileEntity.java
+++ b/src/main/java/cyano/electricadvantage/machines/ElectricFurnaceTileEntity.java
@@ -107,7 +107,7 @@ public class ElectricFurnaceTileEntity extends ElectricMachineTileEntity{
 
 	@Override
 	protected void loadFrom(NBTTagCompound tagRoot) {
-		NBTTagList burnTimes = tagRoot.getTagList("cookTime", 2);
+		NBTTagList burnTimes = tagRoot.getTagList("cookTime", 4);
 		for(int i = 0; i < numberOfInputSlots(); i++){
 			burnTime[i] = ((NBTTagShort)burnTimes.get(i)).getShort();
 		}


### PR DESCRIPTION
In 1.10.2 it seems that NBTTagCompound.getTagList() uses the second parameter as

the number of items to return. The Electric Arc Furnace has 4 input slots, but
the code was only asking for 2 items to be returned. This changes that to be 4,
which should work until the next version gets written.