### PR TITLE
Properly fix issue #2

### DIFF
--- a/src/main/java/cyano/electricadvantage/machines/ElectricCrusherTileEntity.java
+++ b/src/main/java/cyano/electricadvantage/machines/ElectricCrusherTileEntity.java
@@ -113,7 +113,7 @@ public class ElectricCrusherTileEntity extends ElectricMachineTileEntity{
 	@Override
 	protected void loadFrom(NBTTagCompound tagRoot) {
 		NBTTagList times = tagRoot.getTagList("smashTime", 2);
-		for(int i = 0; i < numberOfInputSlots(); i++){
+		for(int i = 0; i < numberOfInputSlots() && i < times.tagCount(); i++){
 			smashTime[i] = ((NBTTagShort)times.get(i)).getShort();
 		}
 	}

--- a/src/main/java/cyano/electricadvantage/machines/ElectricFurnaceTileEntity.java
+++ b/src/main/java/cyano/electricadvantage/machines/ElectricFurnaceTileEntity.java
@@ -107,8 +107,8 @@ public class ElectricFurnaceTileEntity extends ElectricMachineTileEntity{
 
 	@Override
 	protected void loadFrom(NBTTagCompound tagRoot) {
-		NBTTagList burnTimes = tagRoot.getTagList("cookTime", 4);
-		for(int i = 0; i < numberOfInputSlots(); i++){
+		NBTTagList burnTimes = tagRoot.getTagList("cookTime", 2);
+		for(int i = 0; i < numberOfInputSlots() && i < burnTimes.tagCount(); i++){
 			burnTime[i] = ((NBTTagShort)burnTimes.get(i)).getShort();
 		}
 	}


### PR DESCRIPTION
At some point the NBT loading code in the Furnace and Crusher broke and they were requesting data that was off the end of the returned tag list. This led to graphical glitches in other mods, for some reason, as the NBT loading code was generating an error while trying to, wrongly, cast an NBTTagEnd to an NBTTagShort.

This - a proper fix - stops the loop if it tries to index past the end of the array by checking against the tag count of the list.